### PR TITLE
Feature/variable fileupload limit and misc

### DIFF
--- a/environments/dev.env.template
+++ b/environments/dev.env.template
@@ -1,6 +1,8 @@
 NODE_ENV=dev
 # PORT=3000
 USE_API_BASE_PATH=false
+# FILE_UPLOAD_LIMIT=
+# APPLICATION_TITLE=
 
 ## Flag is shared between API and UI
 USE_CERN_SSO=false

--- a/environments/dev.env.template
+++ b/environments/dev.env.template
@@ -2,7 +2,7 @@ NODE_ENV=dev
 # PORT=3000
 USE_API_BASE_PATH=false
 # FILE_UPLOAD_LIMIT=
-# APPLICATION_TITLE=
+# APPLICATION_NAME=
 
 ## Flag is shared between API and UI
 USE_CERN_SSO=false

--- a/environments/prod.env.template
+++ b/environments/prod.env.template
@@ -1,6 +1,8 @@
 NODE_ENV=prod
 # PORT=3000
 USE_API_BASE_PATH=false
+# FILE_UPLOAD_LIMIT=
+# APPLICATION_TITLE=
 
 ## Flag is shared between API and UI
 USE_CERN_SSO=false

--- a/environments/prod.env.template
+++ b/environments/prod.env.template
@@ -2,7 +2,7 @@ NODE_ENV=prod
 # PORT=3000
 USE_API_BASE_PATH=false
 # FILE_UPLOAD_LIMIT=
-# APPLICATION_TITLE=
+# APPLICATION_NAME=
 
 ## Flag is shared between API and UI
 USE_CERN_SSO=false

--- a/environments/test.env.template
+++ b/environments/test.env.template
@@ -1,6 +1,8 @@
 NODE_ENV=test
 # PORT=3000
 USE_API_BASE_PATH=false
+# FILE_UPLOAD_LIMIT=
+# APPLICATION_TITLE=
 
 ## Flag is shared between API and UI
 USE_CERN_SSO=false

--- a/environments/test.env.template
+++ b/environments/test.env.template
@@ -2,7 +2,7 @@ NODE_ENV=test
 # PORT=3000
 USE_API_BASE_PATH=false
 # FILE_UPLOAD_LIMIT=
-# APPLICATION_TITLE=
+# APPLICATION_NAME=
 
 ## Flag is shared between API and UI
 USE_CERN_SSO=false

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -7,7 +7,7 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { USE_API_BASE_PATH } from './constants';
+import { USE_API_BASE_PATH, APPLICATION_TITLE } from './constants';
 
 @Injectable()
 export class AppService {
@@ -18,7 +18,7 @@ export class AppService {
         return [
             `
             <h1 style="font-family: sans-serif; text-align: center; margin-top: 10rem;">
-                Welcome to the Jiskefet API
+                Welcome to the ${APPLICATION_TITLE} API
                 <br>
                 <br>
                 <a href="${USE_API_BASE_PATH === 'true' ? '/api' : ''}/doc/">

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -7,7 +7,7 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { USE_API_BASE_PATH, APPLICATION_TITLE } from './constants';
+import { USE_API_BASE_PATH, APPLICATION_NAME } from './constants';
 
 @Injectable()
 export class AppService {
@@ -18,7 +18,7 @@ export class AppService {
         return [
             `
             <h1 style="font-family: sans-serif; text-align: center; margin-top: 10rem;">
-                Welcome to the ${APPLICATION_TITLE} API
+                Welcome to the ${APPLICATION_NAME} API
                 <br>
                 <br>
                 <a href="${USE_API_BASE_PATH === 'true' ? '/api' : ''}/doc/">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,7 @@ export const PORT = process.env.PORT ? process.env.PORT : 3000;
 export const USE_API_BASE_PATH = process.env.USE_API_BASE_PATH;
 export const USE_CERN_SSO = process.env.USE_CERN_SSO;
 export const FILE_UPLOAD_LIMIT = process.env.FILE_UPLOAD_LIMIT ? +process.env.FILE_UPLOAD_LIMIT : 5;
-export const APPLICATION_TITLE = process.env.APPLICATION_TITLE ? process.env.APPLICATION_TITLE : 'Jiskefet';
+export const APPLICATION_NAME = process.env.APPLICATION_NAME ? process.env.APPLICATION_NAME : 'Jiskefet';
 
 // Database settings
 export const TYPEORM_CONNECTION = process.env.TYPEORM_CONNECTION ? process.env.TYPEORM_CONNECTION : 'mysql';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const PORT = process.env.PORT ? process.env.PORT : 3000;
 export const USE_API_BASE_PATH = process.env.USE_API_BASE_PATH;
 export const USE_CERN_SSO = process.env.USE_CERN_SSO;
 export const FILE_UPLOAD_LIMIT = process.env.FILE_UPLOAD_LIMIT ? +process.env.FILE_UPLOAD_LIMIT : 5;
+export const APPLICATION_TITLE = process.env.APPLICATION_TITLE ? process.env.APPLICATION_TITLE : 'Jiskefet';
 
 // Database settings
 export const TYPEORM_CONNECTION = process.env.TYPEORM_CONNECTION ? process.env.TYPEORM_CONNECTION : 'mysql';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ dotenv.config();
 export const PORT = process.env.PORT ? process.env.PORT : 3000;
 export const USE_API_BASE_PATH = process.env.USE_API_BASE_PATH;
 export const USE_CERN_SSO = process.env.USE_CERN_SSO;
+export const FILE_UPLOAD_LIMIT = process.env.FILE_UPLOAD_LIMIT ? +process.env.FILE_UPLOAD_LIMIT : 5;
 
 // Database settings
 export const TYPEORM_CONNECTION = process.env.TYPEORM_CONNECTION ? process.env.TYPEORM_CONNECTION : 'mysql';

--- a/src/controllers/attachment.controller.ts
+++ b/src/controllers/attachment.controller.ts
@@ -72,6 +72,10 @@ export class AttachmentController {
     }
 
     @Post()
+    @ApiOperation({
+        title: 'Creates an attachment for a log with a file upload field through the Swagger UI.',
+        description: 'This endpoint is only available in dev modus'
+    })
     @ApiConsumes('multipart/form-data')
     @ApiImplicitFile({ name: 'file', required: false })
     @UseInterceptors(FileInterceptor('file', { limits: { fileSize: FILE_UPLOAD_LIMIT * 1024 * 1024 } }))

--- a/src/controllers/attachment.controller.ts
+++ b/src/controllers/attachment.controller.ts
@@ -6,14 +6,37 @@
  * copied verbatim in the file "LICENSE"
  */
 
-import { ApiUseTags, ApiBearerAuth, ApiOperation, ApiOkResponse, ApiNotFoundResponse } from '@nestjs/swagger';
-import { Controller, Get, Param, UseGuards, UseFilters } from '@nestjs/common';
+import {
+    ApiUseTags,
+    ApiBearerAuth,
+    ApiOperation,
+    ApiOkResponse,
+    ApiNotFoundResponse,
+    ApiConsumes,
+    ApiImplicitFile
+} from '@nestjs/swagger';
+import {
+    Controller,
+    Get,
+    Param,
+    UseGuards,
+    UseFilters,
+    Post,
+    Body,
+    UploadedFile,
+    UseInterceptors,
+    FileInterceptor,
+    NotFoundException
+} from '@nestjs/common';
 import { AttachmentService } from '../services/attachment.service';
 import { AuthGuard } from '@nestjs/passport';
-import { createResponseItems, createErrorResponse } from '../helpers/response.helper';
+import { createResponseItems, createErrorResponse, createResponseItem } from '../helpers/response.helper';
 import { ResponseObject } from '../interfaces/response_object.interface';
 import { Attachment } from '../entities/attachment.entity';
 import { HttpExceptionFilter } from '../filters/httpexception.filter';
+import { CreateAttachmentDto } from '../dtos/create.attachment.dto';
+import { FileDto } from '../dtos/file.dto';
+import { FILE_UPLOAD_LIMIT } from '../constants';
 
 @ApiUseTags('attachments')
 @ApiBearerAuth()
@@ -45,6 +68,32 @@ export class AttachmentController {
             return createResponseItems(attachmentsById);
         } catch (error) {
             return createErrorResponse(error);
+        }
+    }
+
+    @Post()
+    @ApiConsumes('multipart/form-data')
+    @ApiImplicitFile({ name: 'file', required: false })
+    @UseInterceptors(FileInterceptor('file', { limits: { fileSize: FILE_UPLOAD_LIMIT * 1024 * 1024 } }))
+    async uploadFile(
+        @Body() logId: number,
+        @UploadedFile() file?: FileDto): Promise<ResponseObject<Attachment>> {
+        switch (process.env.NODE_ENV) {
+            case 'dev':
+                try {
+                    const attachment: CreateAttachmentDto = {
+                        fileName: file.originalname,
+                        fileMime: file.mimetype,
+                        fileData: Buffer.from(file.buffer).toString('base64'),
+                        creationTime: new Date()
+                    };
+                    console.log(`file size is ${file.size}`);
+                    return await createResponseItem(this.attachmentservice.create(logId, attachment));
+                } catch (error) {
+                    return createErrorResponse(error);
+                }
+            default:
+                throw new NotFoundException();
         }
     }
 }

--- a/src/dtos/create.attachment.dto.ts
+++ b/src/dtos/create.attachment.dto.ts
@@ -8,6 +8,7 @@
 
 import { ApiModelProperty } from '@nestjs/swagger';
 import { IsString, IsBase64, IsByteLength, IsOptional } from 'class-validator';
+import { FILE_UPLOAD_LIMIT } from '../constants';
 
 export class CreateAttachmentDto {
 
@@ -44,8 +45,8 @@ export class CreateAttachmentDto {
         description: 'The base64 encoded file data.',
     })
     @IsBase64()
-    @IsByteLength(1, 5000000, {
-        message: 'File data cannot be larger than 5MB', // Limits the base64 string to 5MB
+    @IsByteLength(1, FILE_UPLOAD_LIMIT * 1024 * 1024, {
+        message: `File data cannot be larger than ${FILE_UPLOAD_LIMIT}MB`, // Limits the base64 string to 5MB
     })
     fileData: string;
 }

--- a/src/dtos/file.dto.ts
+++ b/src/dtos/file.dto.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Amsterdam University of Applied Sciences (AUAS)
+ *
+ * This software is distributed under the terms of the
+ * GNU General Public Licence version 3 (GPL) version 3,
+ * copied verbatim in the file "LICENSE"
+ */
+
+export class FileDto {
+
+    fieldname: string;
+
+    originalname: string;
+
+    encoding: string;
+
+    mimetype: string;
+
+    buffer: Buffer;
+
+    size: number;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ function preCheck(): void {
         'PORT',
         'USE_API_BASE_PATH',
         'USE_CERN_SSO',
+        'FILE_UPLOAD_LIMIT',
         'TYPEORM_CONNECTION',
         'TYPEORM_HOST',
         'TYPEORM_USERNAME',
@@ -47,6 +48,7 @@ function preCheck(): void {
         `regex:${Regex.PORT_NUMBER}`,
         `regex:${Regex.BOOLEAN}`,
         `regex:${Regex.BOOLEAN}`,
+        'typeof:isNumber',
         'string:mysql, postgres, mariadb, mssql, mongodb',
         `regex:${Regex.IP_OR_URL_OR_LOCALHOST}`,
         '',
@@ -105,8 +107,8 @@ async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule);
     app.enableCors();
     // Increases the packet limit to 15MB instead of the default 100kb
-    app.use(bodyParser.json({ limit: 15000000 }));
-    app.use(bodyParser.urlencoded({ limit: 15000000, extended: true }));
+    // app.use(bodyParser.json({ limit: 5000000 }));
+    // app.use(bodyParser.urlencoded({ limit: 5000000, extended: true }));
 
     const options = new DocumentBuilder()
         .setTitle('Jiskefet')

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { InfoLogService } from './services/infolog.service';
 import * as cron from 'node-cron';
 import { EnvironmentUtility } from './utility/env.utility';
 import { Regex } from './enums/env.enum';
-import { PORT, USE_CERN_SSO, USE_API_BASE_PATH, USE_INFO_LOGGER } from './constants';
+import { PORT, USE_CERN_SSO, USE_API_BASE_PATH, USE_INFO_LOGGER, APPLICATION_TITLE } from './constants';
 
 /**
  * Check the .env against the array of variables.
@@ -28,6 +28,7 @@ function preCheck(): void {
         'USE_API_BASE_PATH',
         'USE_CERN_SSO',
         'FILE_UPLOAD_LIMIT',
+        'APPLICATION_TITLE',
         'TYPEORM_CONNECTION',
         'TYPEORM_HOST',
         'TYPEORM_USERNAME',
@@ -49,14 +50,15 @@ function preCheck(): void {
         `regex:${Regex.BOOLEAN}`,
         `regex:${Regex.BOOLEAN}`,
         'typeof:isNumber',
-        'string:mysql, postgres, mariadb, mssql, mongodb',
+        '',
+        'matches:mysql, postgres, mariadb, mssql, mongodb',
         `regex:${Regex.IP_OR_URL_OR_LOCALHOST}`,
         '',
         '',
         '',
         `regex:${Regex.PORT_NUMBER}`,
         `regex:${Regex.BOOLEAN}`,
-        'string:true, false, all, query, error, schema, warn, info, log',
+        'matches:true, false, all, query, error, schema, warn, info, log',
         '',
         '',
         '',
@@ -111,7 +113,7 @@ async function bootstrap(): Promise<void> {
     // app.use(bodyParser.urlencoded({ limit: 5000000, extended: true }));
 
     const options = new DocumentBuilder()
-        .setTitle('Jiskefet')
+        .setTitle(APPLICATION_TITLE)
         .setVersion('0.1.0')
         .addTag('logs')
         .addTag('runs')
@@ -120,9 +122,7 @@ async function bootstrap(): Promise<void> {
     if (USE_API_BASE_PATH === 'true') {
         // set /api as basePath for non local
         options.setBasePath('/api');
-        options.setDescription('Running with /api base path');
-    } else {
-        options.setDescription('Running without /api base path');
+        // options.setDescription('Running with /api base path');
     }
 
     const swaggerInfo = options.build();

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { InfoLogService } from './services/infolog.service';
 import * as cron from 'node-cron';
 import { EnvironmentUtility } from './utility/env.utility';
 import { Regex } from './enums/env.enum';
-import { PORT, USE_CERN_SSO, USE_API_BASE_PATH, USE_INFO_LOGGER, APPLICATION_TITLE } from './constants';
+import { PORT, USE_CERN_SSO, USE_API_BASE_PATH, USE_INFO_LOGGER, APPLICATION_NAME } from './constants';
 
 /**
  * Check the .env against the array of variables.
@@ -28,7 +28,7 @@ function preCheck(): void {
         'USE_API_BASE_PATH',
         'USE_CERN_SSO',
         'FILE_UPLOAD_LIMIT',
-        'APPLICATION_TITLE',
+        'APPLICATION_NAME',
         'TYPEORM_CONNECTION',
         'TYPEORM_HOST',
         'TYPEORM_USERNAME',
@@ -113,7 +113,7 @@ async function bootstrap(): Promise<void> {
     // app.use(bodyParser.urlencoded({ limit: 5000000, extended: true }));
 
     const options = new DocumentBuilder()
-        .setTitle(APPLICATION_TITLE)
+        .setTitle(APPLICATION_NAME)
         .setVersion('0.1.0')
         .addTag('logs')
         .addTag('runs')

--- a/src/services/setting.service.ts
+++ b/src/services/setting.service.ts
@@ -8,7 +8,7 @@
 
 import { Injectable } from '@nestjs/common';
 import { Setting } from '../interfaces/setting.interface';
-import { USE_CERN_SSO, CLIENT_ID, AUTH_REDIRECT_URI } from '../constants';
+import { USE_CERN_SSO, CLIENT_ID, AUTH_REDIRECT_URI, FILE_UPLOAD_LIMIT } from '../constants';
 
 @Injectable()
 export class SettingService {
@@ -16,17 +16,21 @@ export class SettingService {
     async getSettings(): Promise<Setting> {
         if (USE_CERN_SSO === 'true') {
             return {
-                    ['USE_CERN_SSO']: USE_CERN_SSO,
-                    ['AUTH_URL']:
-                        `https://oauth.web.cern.ch/OAuth/Authorize?response_type=code`
-                        + `&client_id=${CLIENT_ID}&redirect_uri=${AUTH_REDIRECT_URI}`
+                ['API_VERSION']: (global as any).apiVersion,
+                ['FILE_UPLOAD_LIMIT']: FILE_UPLOAD_LIMIT.toString(),
+                ['USE_CERN_SSO']: USE_CERN_SSO,
+                ['AUTH_URL']:
+                    `https://oauth.web.cern.ch/OAuth/Authorize?response_type=code`
+                    + `&client_id=${CLIENT_ID}&redirect_uri=${AUTH_REDIRECT_URI}`,
             };
         }
         return {
-                ['USE_CERN_SSO']: USE_CERN_SSO,
-                ['AUTH_URL']:
-                    `https://github.com/login/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&`
-                    + `redirect_uri=${AUTH_REDIRECT_URI}`
+            ['API_VERSION']: (global as any).apiVersion,
+            ['FILE_UPLOAD_LIMIT']: FILE_UPLOAD_LIMIT.toString(),
+            ['USE_CERN_SSO']: USE_CERN_SSO,
+            ['AUTH_URL']:
+                `https://github.com/login/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&`
+                + `redirect_uri=${AUTH_REDIRECT_URI}`
         };
     }
 }

--- a/src/utility/env.utility.ts
+++ b/src/utility/env.utility.ts
@@ -77,6 +77,18 @@ export class EnvironmentUtility {
                             errorMsg.push(`${[keys[i]]} does not end with ${endingString}.`);
                         }
                         break;
+                    case 'typeof':
+                        const typetoCheck: string = values[i].replace('typeof:', '').replace(/\s/g, '');
+                        switch (typetoCheck) {
+                            case 'isNumber':
+                                if (isNaN(constants[keys[i]])) {
+                                    errorMsg.push(`${[keys[i]]} is not a number.`);
+                                }
+                                break;
+                            default:
+                                errorMsg.push(`${typetoCheck} type has not been implemented yet.`);
+                        }
+                        break;
                     default:
                 }
             }

--- a/src/utility/env.utility.ts
+++ b/src/utility/env.utility.ts
@@ -64,9 +64,9 @@ export class EnvironmentUtility {
                             }
                         }
                         break;
-                    case 'string':
+                    case 'matches':
                         let possibleValues: string[];
-                        possibleValues = values[i].replace('string:', '').replace(/\s/g, '').split(',');
+                        possibleValues = values[i].replace('matches:', '').replace(/\s/g, '').split(',');
                         if (possibleValues.indexOf(constants[keys[i]]) === -1) {
                             errorMsg.push(`${[keys[i]]} does not match the possible string(s): ${possibleValues}.`);
                         }


### PR DESCRIPTION
## Added:
-Two new configuration fields have been added:
1. FILE_UPLOAD_LIMIT: this is used to set the upload limit in MB's
2. APPLICATION_NAME: set a custom application name, default is `'Jiskefet'` if left empty. 

- File upload field has been added to the Swagger interface, this endpoint is only available in `dev` mode.
- Setting endpoint returns two extra fields:
1. FILE_UPLOAD_LIMIT, so that the UI can use this value to limit the file upload size.
2. API_VERSION, so that the UI can use this value to display it in the lower left corner.
- `env.utility.ts` can now check if the value is of type number.